### PR TITLE
Fix kain.keymap

### DIFF
--- a/boards/shields/kain/kain.keymap
+++ b/boards/shields/kain/kain.keymap
@@ -8,6 +8,10 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/keys.h>
 
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/keys.h>
+
 / {
     keymap {
         compatible = "zmk,keymap";
@@ -20,19 +24,19 @@
             //                    | GUI | LWR | SPC |   | ENT | RSE  | ALT |
 
             bindings = <
-&mo 3           &kp Q  &kp W  &kp E  &kp R        &kp T        &kp Y                    &kp U                       &kp I      &kp O    &kp P     &mo 4
-&kp ESCAPE      &kp A  &kp S  &kp D  &kp F        &kp G        &kp H                    &kp J                       &kp K      &kp L    &kp SQT   &kp LEFT_ALT
-&kp LEFT_SHIFT  &kp Z  &kp X  &kp C  &kp V        &kp B        &kp N                    &kp M                       &kp COMMA  &kp DOT  &kp FSLH  &kp LEFT_SHIFT
-                              &none  &lt 1 SPACE  &lt 2 TAB    &mt RIGHT_CONTROL ENTER  &mt BACKSPACE LEFT_COMMAND  &none
+&mo 3           &kp Q  &kp W  &kp E           &kp R        &kp T        &kp Y                    &kp U                       &kp I            &kp O    &kp P     &mo 4
+&kp ESCAPE      &kp A  &kp S  &kp D           &kp F        &kp G        &kp H                    &kp J                       &kp K            &kp L    &kp SQT   &kp LEFT_ALT
+&kp LEFT_SHIFT  &kp Z  &kp X  &kp C           &kp V        &kp B        &kp N                    &kp M                       &kp COMMA        &kp DOT  &kp FSLH  &kp LEFT_SHIFT
+                              &kp LEFT_SHIFT  &lt 1 SPACE  &lt 2 TAB    &mt RIGHT_CONTROL ENTER  &mt LEFT_COMMAND BACKSPACE  &kp RIGHT_SHIFT
             >;
         };
 
-        Nav {
+        Nav_and_symbols {
             bindings = <
-&bootloader  &none           &kp UP_ARROW  &kp PG_UP        &none  &none     &kp INS     &none                  &kp UP            &none              &none            &none
-&trans       &kp LEFT_ARROW  &kp DOWN      &kp RIGHT_ARROW  &none  &none     &caps_word  &kp LEFT_PARENTHESIS   &kp LESS_THAN     &kp LEFT_BRACKET   &kp LEFT_BRACE   &trans
-&trans       &none           &none         &kp PG_DN        &none  &none     &kp GRAVE   &kp RIGHT_PARENTHESIS  &kp GREATER_THAN  &kp RIGHT_BRACKET  &kp RIGHT_BRACE  &trans
-                                           &none            &none  &trans    &kp RET     &kp BSPC               &none
+&none   &none  &none           &kp UP          &kp PG_UP        &none     &kp INS     &none                  &kp SEMICOLON     &none              &none            &none
+&trans  &none  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &none     &caps_word  &kp LEFT_PARENTHESIS   &kp LESS_THAN     &kp LEFT_BRACKET   &kp LEFT_BRACE   &trans
+&trans  &none  &none           &none           &kp PG_DN        &none     &kp GRAVE   &kp RIGHT_PARENTHESIS  &kp GREATER_THAN  &kp RIGHT_BRACKET  &kp RIGHT_BRACE  &trans
+                               &trans          &none            &trans    &kp RET     &kp BSPC               &trans
             >;
         };
 
@@ -41,7 +45,7 @@
 &none   &none         &none         &none     &kp UNDERSCORE  &kp NON_US_BACKSLASH    &kp EQUAL     &kp PLUS  &kp MINUS  &kp ASTERISK  &kp SLASH      &none
 &trans  &kp NUMBER_1  &kp NUMBER_2  &kp N3    &kp NUMBER_4    &kp N5                  &kp NUMBER_6  &kp N7    &kp N8     &kp N9        &kp N0         &trans
 &trans  &kp GRAVE     &none         &kp HASH  &none           &none                   &none         &none     &none      &none         &kp SEMICOLON  &trans
-                                    &trans    &none           &kp TAB                 &trans        &trans    &trans
+                                    &trans    &trans          &none                   &trans        &trans    &trans
             >;
         };
 
@@ -56,10 +60,10 @@
 
         Right_bootloader {
             bindings = <
-&trans  &trans  &trans  &trans  &trans  &trans    &trans  &trans  &trans  &trans  &bootloader  &trans
-&trans  &trans  &trans  &trans  &trans  &trans    &trans  &trans  &trans  &trans  &trans       &trans
-&trans  &trans  &trans  &trans  &trans  &trans    &trans  &trans  &trans  &trans  &trans       &trans
-                        &trans  &trans  &trans    &trans  &trans  &trans
+&trans  &bootloader  &none  &none  &none  &none    &none  &none  &none  &none  &bootloader  &none
+&none   &none        &none  &none  &none  &none    &none  &none  &none  &none  &none        &none
+&none   &none        &none  &none  &none  &none    &none  &none  &none  &none  &none        &none
+                            &none  &none  &none    &none  &none  &none
             >;
         };
     };

--- a/boards/shields/kain/kain.keymap
+++ b/boards/shields/kain/kain.keymap
@@ -12,6 +12,10 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/keys.h>
 
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/keys.h>
+
 / {
     keymap {
         compatible = "zmk,keymap";
@@ -60,11 +64,12 @@
 
         Right_bootloader {
             bindings = <
-&trans  &bootloader  &none  &none  &none  &none    &none  &none  &none  &none  &bootloader  &none
-&none   &none        &none  &none  &none  &none    &none  &none  &none  &none  &none        &none
-&none   &none        &none  &none  &none  &none    &none  &none  &none  &none  &none        &none
-                            &none  &none  &none    &none  &none  &none
+&trans  &none  &none  &none  &none  &none    &none  &none  &none  &none  &bootloader  &none
+&none   &none  &none  &none  &none  &none    &none  &none  &none  &none  &none        &none
+&none   &none  &none  &none  &none  &none    &none  &none  &none  &none  &none        &none
+                      &none  &none  &none    &none  &none  &none
             >;
         };
     };
 };
+

--- a/boards/shields/kain/kain.keymap
+++ b/boards/shields/kain/kain.keymap
@@ -64,10 +64,10 @@
 
         Right_bootloader {
             bindings = <
-&trans  &none  &none  &none  &none  &none    &none  &none  &none  &none  &bootloader  &none
-&none   &none  &none  &none  &none  &none    &none  &none  &none  &none  &none        &none
-&none   &none  &none  &none  &none  &none    &none  &none  &none  &none  &none        &none
-                      &none  &none  &none    &none  &none  &none
+&none  &none  &none  &none  &none  &none    &none  &none  &none  &none  &bootloader  &none
+&none  &none  &none  &none  &none  &none    &none  &none  &none  &none  &none        &none
+&none  &none  &none  &none  &none  &none    &none  &none  &none  &none  &none        &none
+                     &none  &none  &none    &none  &none  &none
             >;
         };
     };


### PR DESCRIPTION
Clean up

- The arrow cluster is in the wrong place.  Need to shift one column to the right
- Backspace / command are reversed (hold tap is wrong)
- Consider shift on the free thumb buttons
- TAB shouldn’t be on the Number layer since it’s the layer key.  Space should be on the middle key.
- UP arrow left over on right hand side of the nav
- Remame Nav nav and symbols.