### PR TITLE
Add wakeup -source to kscan node.

### DIFF
--- a/boards/shields/kain/kain.dtsi
+++ b/boards/shields/kain/kain.dtsi
@@ -32,8 +32,8 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)  RC(2,6) RC(2,7) RC(2,8) RC(2,9)
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-
         diode-direction = "col2row";
+        wakeup-source;
     };
 
     // TODO: per-key RGB node(s)?


### PR DESCRIPTION
This is newly required with support for soft-off.

See https://github.com/mmccoyd/zmk-config/issues/11