### PR TITLE
Update kain.keymap

### DIFF
--- a/boards/shields/kain/kain.keymap
+++ b/boards/shields/kain/kain.keymap
@@ -10,6 +10,8 @@
 #include <dt-bindings/zmk/mouse.h>
 #include <dt-bindings/zmk/outputs.h>
 
+&lt { tapping-term-ms = <300>; };
+
 / {
     behaviors {
         smart_shift: smart_shift {
@@ -62,7 +64,7 @@
             bindings = <
 &none   &none  &kp PG_UP       &kp UP          &kp UNDERSCORE   &kp PIPE     &kp COLON      &kp SQT                &none             &none              &none            &none
 &trans  &none  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &kp SLASH    &kp SEMICOLON  &kp LEFT_PARENTHESIS   &kp LESS_THAN     &kp LEFT_BRACKET   &kp LEFT_BRACE   &trans
-&trans  &none  &kp PG_DN       &none           &kp MINUS        &kp HASH     &kp GRAVE      &kp RIGHT_PARENTHESIS  &kp GREATER_THAN  &kp RIGHT_BRACKET  &kp RIGHT_BRACE  &trans
+&trans  &none  &kp PG_DN       &kp LG(C)       &kp MINUS        &kp HASH     &kp GRAVE      &kp RIGHT_PARENTHESIS  &kp GREATER_THAN  &kp RIGHT_BRACKET  &kp RIGHT_BRACE  &trans
                                &trans          &none            &trans       &trans         &trans                 &trans
             >;
         };

--- a/keymap-drawer/kain.svg
+++ b/keymap-drawer/kain.svg
@@ -75,6 +75,9 @@ svg.keymap {
 /* default key styling */
 rect.key {
     fill: #f6f8fa;
+}
+
+rect.key, rect.combo {
     stroke: #c9cccf;
     stroke-width: 1;
 }
@@ -110,7 +113,16 @@ text.label {
     font-weight: bold;
     text-anchor: start;
     stroke: white;
-    stroke-width: 2;
+    stroke-width: 4;
+    paint-order: stroke;
+}
+
+/* styling for optional footer */
+text.footer {
+    text-anchor: end;
+    dominant-baseline: auto;
+    stroke: white;
+    stroke-width: 4;
     paint-order: stroke;
 }
 
@@ -127,6 +139,10 @@ text.hold {
 text.shifted {
     text-anchor: middle;
     dominant-baseline: hanging;
+}
+
+text.layer-activator {
+    text-decoration: underline;
 }
 
 /* styling for hold/shifted label text in combo box */
@@ -160,12 +176,13 @@ path.combo {
 /* End Tabler Icons Cleanup */
 </style>
 <g transform="translate(30, 0)" class="layer-Base_QWERTY">
-<text x="0" y="28" class="label">Base_QWERTY:</text>
+<text x="0" y="28" class="label" id="Base_QWERTY">Base_QWERTY:</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 42)" class="key keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">Sys</text>
-</g>
+<a href="#Sys">
+<text x="0" y="0" class="key tap layer-activator">Sys</text>
+</a></g>
 <g transform="translate(84, 42)" class="key keypos-1">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">Q</text>
@@ -208,8 +225,9 @@ path.combo {
 </g>
 <g transform="translate(756, 42)" class="key keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">Sys</text>
-</g>
+<a href="#Sys">
+<text x="0" y="0" class="key tap layer-activator">Sys</text>
+</a></g>
 <g transform="translate(28, 98)" class="key keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">ESCAPE</text>
@@ -313,13 +331,15 @@ path.combo {
 <g transform="translate(280, 224)" class="key keypos-37">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <use href="#mdi:keyboard-space" xlink:href="#mdi:keyboard-space" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-space"/>
-<text x="0" y="24" class="key hold">Nav+</text>
-</g>
+<a href="#Nav">
+<text x="0" y="24" class="key hold layer-activator">Nav+</text>
+</a></g>
 <g transform="translate(336, 238)" class="key keypos-38">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <use href="#mdi:keyboard-tab" xlink:href="#mdi:keyboard-tab" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-tab"/>
-<text x="0" y="24" class="key hold">Number</text>
-</g>
+<a href="#Number">
+<text x="0" y="24" class="key hold layer-activator">Number</text>
+</a></g>
 <g transform="translate(448, 238)" class="key keypos-39">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <use href="#mdi:backspace-outline" xlink:href="#mdi:backspace-outline" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:backspace-outline"/>
@@ -337,7 +357,7 @@ path.combo {
 </g>
 </g>
 <g transform="translate(30, 322)" class="layer-Middlemak">
-<text x="0" y="28" class="label">Middlemak:</text>
+<text x="0" y="28" class="label" id="Middlemak">Middlemak:</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 42)" class="key trans keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
@@ -498,7 +518,7 @@ path.combo {
 </g>
 </g>
 <g transform="translate(30, 644)" class="layer-Windows">
-<text x="0" y="28" class="label">Windows:</text>
+<text x="0" y="28" class="label" id="Windows">Windows:</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 42)" class="key trans keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
@@ -632,7 +652,7 @@ path.combo {
 </g>
 </g>
 <g transform="translate(30, 966)" class="layer-Nav+">
-<text x="0" y="28" class="label">Nav+:</text>
+<text x="0" y="28" class="label" id="Nav">Nav+:</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 42)" class="key keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -737,6 +757,9 @@ path.combo {
 </g>
 <g transform="translate(196, 140)" class="key keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">Gui+</tspan><tspan x="0" dy="1.2em">C</tspan>
+</text>
 </g>
 <g transform="translate(252, 147)" class="key keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -790,7 +813,7 @@ path.combo {
 </g>
 </g>
 <g transform="translate(30, 1288)" class="layer-Number">
-<text x="0" y="28" class="label">Number:</text>
+<text x="0" y="28" class="label" id="Number">Number:</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 42)" class="key keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -951,7 +974,7 @@ path.combo {
 </g>
 </g>
 <g transform="translate(30, 1610)" class="layer-Sys">
-<text x="0" y="28" class="label">Sys:</text>
+<text x="0" y="28" class="label" id="Sys">Sys:</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 42)" class="key held keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key held"/>
@@ -1037,18 +1060,21 @@ path.combo {
 </g>
 <g transform="translate(84, 154)" class="key keypos-25">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">Base_QWERTY</tspan></text>
-<text x="0" y="24" class="key hold">toggle</text>
+<a href="#Base_QWERTY">
+<text x="0" y="0" class="key tap layer-activator"><tspan style="font-size: 64%">Base_QWERTY</tspan></text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(140, 147)" class="key keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 78%">Middlemak</tspan></text>
-<text x="0" y="24" class="key hold">toggle</text>
+<a href="#Middlemak">
+<text x="0" y="0" class="key tap layer-activator"><tspan style="font-size: 78%">Middlemak</tspan></text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(196, 140)" class="key keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">Windows</text>
-<text x="0" y="24" class="key hold">toggle</text>
+<a href="#Windows">
+<text x="0" y="0" class="key tap layer-activator">Windows</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(252, 147)" class="key keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/keymap-drawer/kain.yaml
+++ b/keymap-drawer/kain.yaml
@@ -112,7 +112,7 @@ layers:
   - - {type: trans}
     - ''
     - PG DN
-    - ''
+    - Gui+ C
     - '-'
     - '#'
     - '`'


### PR DESCRIPTION
* Add a command-c (cut) key on the nav layer.  Effectively makes nav-c cut.  This is useful for left hand cut while the right hand is on the mouse.

* Increase the tapping term for layer-tap as I keep activating nav when I want space when typing quickly.